### PR TITLE
Refactor api endpoints to rest principles

### DIFF
--- a/store_monitor/urls.py
+++ b/store_monitor/urls.py
@@ -2,9 +2,16 @@ from django.urls import path
 from .views import *
 
 urlpatterns = [
-    path('trigger_report/', TriggerReportView.as_view(), name='trigger_report'),
-    path('get_report/<str:report_id>/', GetReportView.as_view(), name='get_report'),
-    path('showdata/<str:table>',DataView.as_view(), name='show_data'),
-    path('erase_data/',CleanDBView.as_view(),name='clean_db'),
-    path('load_data/',LoadDataView.as_view(),name='load_from_csv')
+    # Reports resource
+    path('reports/', TriggerReportView.as_view(), name='reports'),  # POST to create/trigger a report
+    path('reports/<str:report_id>/', GetReportView.as_view(), name='report-detail'),  # GET report status/content
+
+    # Domain resources (read-only lists)
+    path('timezones/', DataView.as_view(), {'table': 'timezone'}, name='timezones-list'),
+    path('business-hours/', DataView.as_view(), {'table': 'businesshour'}, name='business-hours-list'),
+    path('store-statuses/', DataView.as_view(), {'table': 'storestatus'}, name='store-statuses-list'),
+
+    # Data management
+    path('data/', CleanDBView.as_view(), name='data'),  # DELETE to clear all imported data
+    path('data-imports/', LoadDataView.as_view(), name='data-imports'),  # POST to load data from CSVs
 ]


### PR DESCRIPTION
Refactor Django URL patterns to follow REST principles.

---
<a href="https://cursor.com/background-agent?bcId=bc-6498aa30-7ce9-438c-8e25-afa68151e46f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6498aa30-7ce9-438c-8e25-afa68151e46f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

